### PR TITLE
Standardize terminology: replace "fitted" with "fit"

### DIFF
--- a/PowerT/Config/AppearanceConfig.cs
+++ b/PowerT/Config/AppearanceConfig.cs
@@ -18,10 +18,10 @@ public sealed class AppearanceConfig
     public ColorGradientConfig ColorGradientConfig { get; set; } = new();
 
     /// <summary>
-    /// Gets or sets the line width of the fitted lines.
+    /// Gets or sets the line width of the fit lines.
     /// </summary>
-    [XmlElement("fitted-width")]
-    public int FittedWidth { get; set; } = 3;
+    [XmlElement("fit-width")]
+    public int FitWidth { get; set; } = 3;
 
     /// <summary>
     /// Gets or sets the font of the axis labels.

--- a/PowerT/Controls/ParamsRow.cs
+++ b/PowerT/Controls/ParamsRow.cs
@@ -36,9 +36,9 @@ internal class ParamsRow : DataGridViewRow
     internal required Series ObservedSeries { get; init; }
 
     /// <summary>
-    /// Gets or sets the series representing the fitted data.
+    /// Gets or sets the series representing the fit data.
     /// </summary>
-    internal required Series FittedSeries { get; init; }
+    internal required Series FitSeries { get; init; }
 
     /// <summary>
     /// Gets or sets a value indicating whether to show data on the plot.

--- a/PowerT/Controls/ParamsTable.cs
+++ b/PowerT/Controls/ParamsTable.cs
@@ -246,9 +246,9 @@ internal sealed class ParamsTable : DataGridView
         if (e.ColumnIndex == 0) // Show
         {
             var series = row.ObservedSeries;
-            var fitted = row.FittedSeries;
+            var fit = row.FitSeries;
 
-            series.Enabled = fitted.Enabled = row.Show;
+            series.Enabled = fit.Enabled = row.Show;
         }
 
         if (e.ColumnIndex == 4 && this.SyncAlpha) // Alpha
@@ -275,12 +275,12 @@ internal sealed class ParamsTable : DataGridView
         if (e.ColumnIndex is >= 2 and <= 6) // Params
         {
             var observed = row.ObservedSeries;
-            var fitted = row.FittedSeries;
+            var fit = row.FitSeries;
 
-            fitted.Points.Clear();
+            fit.Points.Clear();
             var f = row.Parameters.GetFunction();
             foreach (var time in row.Decay.Times)
-                fitted.Points.AddXY(time, f(time));
+                fit.Points.AddXY(time, f(time));
             row.Cells[7].ToolTipText = row.Parameters.ToString();
         }
 
@@ -395,16 +395,16 @@ internal sealed class ParamsTable : DataGridView
     /// <param name="name">The name.</param>
     /// <param name="decay">The decay.</param>
     /// <param name="parameters">The parameters.</param>
-    /// <param name="fitted">The fitted series.</param>
+    /// <param name="fit">The fit series.</param>
     /// <param name="observed">The observed series.</param>
     /// <returns>The added row.</returns>
-    internal ParamsRow Add(string name, Decay decay, Parameters parameters, Series observed, Series fitted)
+    internal ParamsRow Add(string name, Decay decay, Parameters parameters, Series observed, Series fit)
     {
         var row = new ParamsRow() {
             Name = name,
             Decay = decay,
             ObservedSeries = observed,
-            FittedSeries = fitted
+            FitSeries = fit
         };
         var index = this.Rows.Add(row);
 

--- a/PowerT/Program.cs
+++ b/PowerT/Program.cs
@@ -79,14 +79,14 @@ internal static class Program
     }
 
     /// <summary>
-    /// Gets or sets the line widdh of the fitted lines.
+    /// Gets or sets the line widdh of the fit lines.
     /// </summary>
-    internal static int FittedWidth
+    internal static int FitWidth
     {
-        get => Config.AppearanceConfig.FittedWidth;
+        get => Config.AppearanceConfig.FitWidth;
         set
         {
-            Config.AppearanceConfig.FittedWidth = value;
+            Config.AppearanceConfig.FitWidth = value;
             SaveConfig();
         }
     }


### PR DESCRIPTION
Replaced the term "fitted" with "fit" throughout the codebase for consistency and clarity.

This is a destructive change because it changes the name of the `AppearanceConfig.FittedWidth` element.